### PR TITLE
Python Cleanup

### DIFF
--- a/mopidy_mopify/__init__.py
+++ b/mopidy_mopify/__init__.py
@@ -4,7 +4,7 @@ import logging
 import os
 import tornado.web
 import sync
-import update 
+import update
 import mem
 from queuemanager import core
 from queuemanager import frontend
@@ -17,6 +17,7 @@ __ext_name__ = 'mopify'
 __verbosemode__ = False
 
 logger = logging.getLogger(__ext_name__)
+
 
 class MopifyExtension(ext.Extension):
     dist_name = 'Mopidy-Mopify'
@@ -33,8 +34,8 @@ class MopifyExtension(ext.Extension):
         return schema
 
     def setup(self, registry):
-        syncinstance = sync.Sync();
-        
+        sync.Sync()
+
         mem.queuemanager = core.QueueManager()
 
         # Add Queuemanager Frontend class
@@ -43,13 +44,14 @@ class MopifyExtension(ext.Extension):
         # Add web extension
         registry.add('http:app', {
             'name': self.ext_name,
-            'factory': mopify_client_factory  
+            'factory': mopify_client_factory
         })
 
         logger.info('Setup Mopify')
 
+
 def mopify_client_factory(config, core):
-    directory = 'debug' if (config.get(__ext_name__)['debug'] == True) else 'min'
+    directory = 'debug' if config.get(__ext_name__)['debug'] is True else 'min'
     mopifypath = os.path.join(os.path.dirname(__file__), 'static', directory)
 
     return [

--- a/mopidy_mopify/queuemanager/core.py
+++ b/mopidy_mopify/queuemanager/core.py
@@ -1,14 +1,12 @@
 from __future__ import unicode_literals
-import os
 
-from .. import mem
 
-class QueueManager:
+class QueueManager(object):
     # Initialize the tracklist
     queue = []
     playlist = []
     shufflememory = []
-    
+
     shuffled = False
     version = 0
 
@@ -23,14 +21,13 @@ class QueueManager:
     def get_shuffle(self):
         return self.shuffled
 
-
     def add_to_queue(self, tracks):
         self.queue.extend(tracks)
         self.version += 1
 
         return {
             'queue': self.queue,
-            'version': self.version            
+            'version': self.version
         }
 
     def add_play_next(self, tracks):
@@ -39,18 +36,18 @@ class QueueManager:
 
         return {
             'queue': self.queue,
-            'version': self.version            
+            'version': self.version
         }
 
     def remove_from_queue(self, tlids):
         self.queue = [tltrack for tltrack in self.queue if tltrack["tlid"] not in tlids]
         self.shufflememory = [tltrack for tltrack in self.shufflememory if tltrack["tlid"] not in tlids]
-        
+
         self.version += 1
 
         return {
             'queue': self.queue,
-            'version': self.version            
+            'version': self.version
         }
 
     def remove_from_playlist(self, tlids):
@@ -61,7 +58,7 @@ class QueueManager:
 
         return {
             'playlist': self.playlist,
-            'version': self.version            
+            'version': self.version
         }
 
     def remove_from_tracklist(self, tlids):
@@ -76,7 +73,7 @@ class QueueManager:
 
         return {
             'queue': self.queue,
-            'version': self.version            
+            'version': self.version
         }
 
     def set_playlist(self, tracks):
@@ -85,7 +82,7 @@ class QueueManager:
 
         return {
             'playlist': self.playlist,
-            'version': self.version            
+            'version': self.version
         }
 
     def shuffle_playlist(self, tracks):

--- a/mopidy_mopify/queuemanager/frontend.py
+++ b/mopidy_mopify/queuemanager/frontend.py
@@ -2,7 +2,6 @@ from __future__ import unicode_literals
 
 from mopidy.core import CoreListener
 import pykka
-import logging
 
 from .. import mem
 

--- a/mopidy_mopify/queuemanager/requesthandler.py
+++ b/mopidy_mopify/queuemanager/requesthandler.py
@@ -1,9 +1,7 @@
 from __future__ import unicode_literals
-import os
 import logging
 
 import tornado.websocket
-from tornado.escape import json_encode
 
 import json
 
@@ -11,8 +9,9 @@ from .. import mem
 
 logger = logging.getLogger(__name__)
 
+
 class RequestHandler(tornado.websocket.WebSocketHandler):
-    
+
     def initialize(self, core, config, instance):
         self.core = core
         self.instance = instance
@@ -35,7 +34,7 @@ class RequestHandler(tornado.websocket.WebSocketHandler):
             args = data['data']
         else:
             args = {}
-            
+
         call = getattr(mem.queuemanager, data['method'])(**args)
 
         result = {

--- a/mopidy_mopify/update.py
+++ b/mopidy_mopify/update.py
@@ -1,9 +1,9 @@
 import os
-import sys
 import tornado.web
 
 from tornado.escape import json_encode
 import subprocess
+
 
 class UpdateRequestHandler(tornado.web.RequestHandler):
     isroot = False
@@ -23,15 +23,12 @@ class UpdateRequestHandler(tornado.web.RequestHandler):
 
     def post(self):
         if not self.isroot:
-            resp = 'Mopidy needs to run as root user to perform an auto-update' 
+            resp = 'Mopidy needs to run as root user to perform an auto-update'
         else:
             try:
                 subprocess.check_call(["pip", "install", "--upgrade", "mopidy-mopify"])
-
-                restart = True
-                resp = 'Update succesfull'
+                resp = 'Update succesful'
             except subprocess.CalledProcessError:
-                restart = False
                 resp = "The auto-update failed"
 
         self.write(json_encode({'response': resp}))


### PR DESCRIPTION
I did a bit of cleanup in the Python code:

- Made it mostly conforming with [PEP8](http://legacy.python.org/dev/peps/pep-0008/), the de-facto standard for Python coding
- Removed some unused imports and variables
- Removed some JavaScript-isms like semicolons and parentheses around if statements
- Simplified some of the logic
- Some classes didn't properly inherit from `object`

I also noticed some things that I'd consider quite dangerous:

- There's a recommendation to run mopidy as root for the auto-update to work. This is quite dangerous, mopidy should **not** be running as root. If you want a setup that can upgrade itself, you could for example promote a setup where people install mopify inside a virtualenv. Then you can install or upgrade dependencies with pip even as a regular user.
- Some code has side effects, e.g. creating a `Sync` instance. That's generally considered bad behavior, and users don't expect it (especially if it messes with the file system).

Nice web UI though, thanks :)