### PR TITLE
Fullscreen for ios when using 'Add to home screen'

### DIFF
--- a/mopidy_mopify/static/min/index.html
+++ b/mopidy_mopify/static/min/index.html
@@ -7,6 +7,7 @@
         <meta http-equiv="X-UA-Compatible" content="IE=edge">
         <meta name="description" content="">
         <meta name="viewport" content="width=device-width, initial-scale=1">
+        <meta name="apple-mobile-web-app-capable" content="yes">
 
         <meta name="version" content="1.5.12">
 


### PR DESCRIPTION
For ios user in Safari there is a 'Add to home screen' function that creates a app on the home screen which is a shortcut to the url. Without this tag it just opens Safari, with it it creates a coo little full screen app. Thanks!